### PR TITLE
Add support for :has() pseudo-class

### DIFF
--- a/lib/match-node.js
+++ b/lib/match-node.js
@@ -15,18 +15,6 @@ function matchType (rule, node) {
   return !rule.tagName || rule.tagName == '*' || rule.tagName == node.type;
 }
 
-function has(rule, node, nodeIndex, parent, props, select) {
-  // FIXME: this needs to actually look at the rule's AST
-  if (rule === '>') {
-    rule = rule.replace(/^>\s*/, '')
-    return node.children && node.children.some(function(child, childIndex) {
-      return matchNode(child, rule, childIndex, node, props, select);
-    });
-  } else {
-    return select(rule, node).length > 0;
-  }
-}
-
 function matchAttrs (rule, node) {
   return !rule.attrs || rule.attrs.every(function (attr) {
     switch (attr.operator) {
@@ -112,7 +100,7 @@ function matchPseudos (rule, node, nodeIndex, parent, props, select) {
         return !matchNode(pseudo.value.rule, node, nodeIndex, parent, props);
 
       case 'has':
-        return has(pseudo.value.rule, node, nodeIndex, parent, props, select);
+        return select(pseudo.value.rule, node).length > 0;
 
       default:
         throw Error('Undefined pseudo-class: ' + pseudo.name);

--- a/lib/match-node.js
+++ b/lib/match-node.js
@@ -4,10 +4,10 @@ module.exports = matchNode;
 
 
 // Match node against a simple selector.
-function matchNode (rule, node, nodeIndex, parent, props) {
+function matchNode (rule, node, nodeIndex, parent, props, select) {
   return matchType(rule, node) &&
     matchAttrs(rule, node) &&
-    matchPseudos(rule, node, nodeIndex, parent, props);
+    matchPseudos(rule, node, nodeIndex, parent, props, select);
 }
 
 
@@ -15,6 +15,17 @@ function matchType (rule, node) {
   return !rule.tagName || rule.tagName == '*' || rule.tagName == node.type;
 }
 
+function has(rule, node, nodeIndex, parent, props, select) {
+  // FIXME: this needs to actually look at the rule's AST
+  if (rule === '>') {
+    rule = rule.replace(/^>\s*/, '')
+    return node.children && node.children.some(function(child, childIndex) {
+      return matchNode(child, rule, childIndex, node, props, select);
+    });
+  } else {
+    return select(rule, node).length > 0;
+  }
+}
 
 function matchAttrs (rule, node) {
   return !rule.attrs || rule.attrs.every(function (attr) {
@@ -58,7 +69,7 @@ function matchAttrs (rule, node) {
 }
 
 
-function matchPseudos (rule, node, nodeIndex, parent, props) {
+function matchPseudos (rule, node, nodeIndex, parent, props, select) {
   return !rule.pseudos || rule.pseudos.every(function (pseudo) {
     switch (pseudo.name) {
       case 'root':
@@ -99,6 +110,9 @@ function matchPseudos (rule, node, nodeIndex, parent, props) {
 
       case 'not':
         return !matchNode(pseudo.value.rule, node, nodeIndex, parent, props);
+
+      case 'has':
+        return has(pseudo.value.rule, node, nodeIndex, parent, props, select);
 
       default:
         throw Error('Undefined pseudo-class: ' + pseudo.name);

--- a/lib/select.js
+++ b/lib/select.js
@@ -44,7 +44,8 @@ select.rule = function (rule, ast) {
   }
 
   function match (rule, node, nodeIndex, parent, props) {
-    if (matchNode.apply(this, arguments)) {
+    var matchArgs = Array.from(arguments).concat(select.rule)
+    if (matchNode.apply(this, matchArgs)) {
       if (rule.rule) {
         search(rule.rule, node, nodeIndex, parent);
       }

--- a/lib/selector.js
+++ b/lib/selector.js
@@ -9,6 +9,7 @@ module.exports = function parseSelector (selector) {
   parser.registerNestingOperators('>', '+', '~');
   parser.registerAttrEqualityMods('^', '*', '$');
   parser.registerSelectorPseudos('not');
+  parser.registerSelectorPseudos('has');
   return compileNthChecks(parser.parse(selector));
 };
 

--- a/test/select.js
+++ b/test/select.js
@@ -350,3 +350,12 @@ test('negation pseudo-class', function (t) {
   ]);
   t.end();
 });
+
+test(':has(selector)', function (t) {
+  t.deepEqual(select(ast, 'list:has(listItem)'), select(ast, 'list'));
+  t.deepEqual(select(ast, 'paragraph:has(linkReference)'),
+              select(ast, 'paragraph').filter(function(para) {
+                return select(para, 'linkReference').length > 0;
+              }));
+  t.end();
+});


### PR DESCRIPTION
The [`:has(selector)` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) matches nodes that _contain_ an element matching the rule's selector, and is part of the [Selectors 4 draft spec](https://drafts.csswg.org/selectors-4/#relational). The tricky thing here was that matching a selector within the pseudo-class handler required passing a reference to the `select.rule` function down to `matchNode()` like [this](https://github.com/shawnbot/unist-util-select/blob/710b45ffa9911da22bc842ff28705c71a9311612/lib/select.js#L47), which may or may not be the "right" thing to do.

I looked into adding support for the `:has(> selector)` syntax to match only direct descendants, but it looks like `css-selector-parser` would need some work to handle that. Another way it could be done is with [`:scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/:scope), a la `:has(:scope > selector)`, but I didn't want to go _too_ far down the rabbit hole without having this work checked first. 😬 