### PR TITLE
Fixes #9

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ function matches(selector, node) {
 }
 
 function select(selector, node) {
-  return any(parse(selector), node, {one: true})[0] || null
+  return any(parse(selector), node, {one: true, any: any})[0] || null
 }
 
 function selectAll(selector, node) {
-  return any(parse(selector), node, {})
+  return any(parse(selector), node, {any: any})
 }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ var any = require('./lib/any')
 var parse = require('./lib/parse')
 
 function matches(selector, node) {
-  return Boolean(any(parse(selector), node, {one: true, shallow: true})[0])
+  return Boolean(
+    any(parse(selector), node, {one: true, shallow: true, any: any})[0]
+  )
 }
 
 function select(selector, node) {

--- a/lib/any.js
+++ b/lib/any.js
@@ -52,7 +52,8 @@ function rule(query, tree, state) {
       scopeNodes: tree.type === 'root' ? tree.children : [tree],
       iterator: iterator,
       one: state.one,
-      shallow: state.shallow
+      shallow: state.shallow,
+      any: state.any
     })
   )
 

--- a/lib/pseudo.js
+++ b/lib/pseudo.js
@@ -5,7 +5,6 @@ module.exports = match
 var zwitch = require('zwitch')
 var not = require('not')
 var convert = require('unist-util-is/convert')
-var anything = require('./any')
 
 var is = convert()
 
@@ -61,6 +60,7 @@ function match(query, node, index, parent, state) {
 function matches(query, node, index, parent, state) {
   var shallow = state.shallow
   var one = state.one
+  var anything = state.any
   var result
 
   state.one = true
@@ -160,6 +160,7 @@ function hasSelector(query, node, index, parent, state) {
   var one = state.one
   var scopeNodes = state.scopeNodes
   var value = appendScope(query.value)
+  var anything = state.any
   var result
 
   state.shallow = false


### PR DESCRIPTION
This PR fixes #9

It is not a bug fix, but rather a code quality improvement. It's purpose is to stop JS bundler complaining about the detected circular dependency.

It does not include any new tests, because it would require testing for circular dependency, not sure what the right approach would be right now. The issue thread shows dependency graphs and a clear resolve of the cyclic dependency that existed before PR.

Note that possible state (context) pollution introduced by passing any down the road from the index.js