### PR TITLE
Failing test: Comma selectors are evaluated independently

### DIFF
--- a/test/all.js
+++ b/test/all.js
@@ -84,5 +84,27 @@ test('all together now', (t) => {
     ]
   )
 
+  t.deepEqual(
+    selectAll(
+      'h1, h2',
+      u('root', [
+        u('h1', 'Alpha'),
+        u('h2', 'Alpha.1'),
+        u('h2', 'Alpha.2'),
+        u('h1', 'Bravo'),
+        u('h2', 'Bravo.1'),
+        u('h2', 'Bravo.2')
+      ])
+    ),
+    [
+      u('h1', 'Alpha'),
+      u('h2', 'Alpha.1'),
+      u('h2', 'Alpha.2'),
+      u('h1', 'Bravo'),
+      u('h2', 'Bravo.1'),
+      u('h2', 'Bravo.2')
+    ]
+  )
+
   t.end()
 })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This PR adds a failing test demonstrating what I think is a bug. I wanted to use `hast-util-select` to assign the correct heading path (`h1.textContent` → `h2.textContent` → `p`) to paragraphs on a document. But it looks like `unist-util-select`’s `selectAll` essentially evaluates `selector.split(',').flatMap(selectAll)`, resulting in out-of-order results.

I noticed that wrapping my selector in `:matches()` causes results to be emitted in the correct order (although doing this prevents me from using nesting selector combinators like `>`, so it doesn’t work for my use case).

I think this should either be fixed (so that the ordering of results from `:matches(a, b)` and `a, b` are the same) or documented as a limitation.

<!--do not edit: pr-->
