### PR TITLE
Update nth-check to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/unist": "^3.0.0",
     "css-selector-parser": "^3.0.0",
     "devlop": "^1.1.0",
-    "nth-check": "^2.0.0",
+    "nth-check": "^3.0.0",
     "zwitch": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This PR updates the `nth-check` dependency from v2 to v3. [Version 3](https://github.com/fb55/nth-check/releases/tag/v3.0.0) is ESM-only, reducing install size.

N.B. locally the same tests failed for me before and after this change, likely due to a mismatch in Node version and/or some dependency versions (there are no lock files in the project). I’m guessing these may also fail here in CI? But I suspect if they do, CI would also fail on `main` — it just hasn’t been run for 3 years.

<!--do not edit: pr-->
